### PR TITLE
vp8_decoder: move eglimage hook registration to constructor

### DIFF
--- a/plugins/vp8_decoder/src/vp8d.c
+++ b/plugins/vp8_decoder/src/vp8d.c
@@ -61,45 +61,6 @@
 
 static OMX_VERSIONTYPE vp8_decoder_version = {{1, 0, 0, 0}};
 
-static OMX_BOOL
-egl_image_validation_hook (const OMX_HANDLETYPE ap_hdl,
-                           OMX_U32 pid, OMX_PTR ap_eglimage,
-                           void *ap_args)
-{
-  const void * p_krn = NULL;
-  const tiz_port_t * p_port = NULL;
-  const tiz_videoport_t * p_videoport = NULL;
-
-  TIZ_DEBUG (ap_hdl, "vp8 decoder EGLImage validation hook : ap_eglimage=[%p]",
-             ap_eglimage);
-
-  /* TODO: */
-  // vp8d_prc_t * ap_prc = NULL;
-
-  assert (ap_hdl);
-  assert (ap_eglimage);
-  assert (!ap_args);
-
-  p_krn = tiz_get_krn (ap_hdl);
-  p_port = tiz_krn_get_port (p_krn, pid);
-  p_videoport = (tiz_videoport_t *) p_port;
-
-  assert (p_videoport);
-
-/*   { */
-/*     const OMX_VIDEO_PORTDEFINITIONTYPE * p_video_portdef */
-/*       = &(p_port->portdef_.format.video); */
-
-/*     if (!p_video_portdef->pNativeWindow) */
-/*       { */
-/*         return OMX_FALSE; */
-/*       } */
-/*   } */
-
-  /* This function must return true or false */
-  return OMX_TRUE;
-}
-
 static OMX_PTR
 instantiate_input_port (OMX_HANDLETYPE ap_hdl)
 {
@@ -210,11 +171,6 @@ OMX_ComponentInit (OMX_HANDLETYPE ap_hdl)
   const tiz_role_factory_t * rf_list[] = {&role_factory};
   tiz_type_factory_t vp8dprc_type;
   const tiz_type_factory_t * tf_list[] = {&vp8dprc_type};
-  const tiz_eglimage_hook_t egl_validation_hook = {
-    ARATELIA_VP8_DECODER_OUTPUT_PORT_INDEX,
-    egl_image_validation_hook,
-    NULL
-  };
 
   strcpy ((OMX_STRING) role_factory.role, ARATELIA_VP8_DECODER_DEFAULT_ROLE);
   role_factory.pf_cport = instantiate_config_port;
@@ -236,10 +192,6 @@ OMX_ComponentInit (OMX_HANDLETYPE ap_hdl)
 
   /* Register the component role */
   tiz_check_omx (tiz_comp_register_roles (ap_hdl, rf_list, 1));
-
-  /* Register egl image validation hook */
-  tiz_check_omx (tiz_comp_register_eglimage_hook
-                     (ap_hdl, &egl_validation_hook));
 
   return OMX_ErrorNone;
 }


### PR DESCRIPTION
- Allow to acces vp8d_prc_t.
- Does not work when registered from OMX_ComponentInit for the
  output port. Somehow to output port is re-created but the hook
  is not copied.

Signed-off-by: Julien Isorce <jisorce@oblong.com>