### PR TITLE
Display proper file path for systemwide configuration in help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ the file for more information):
 ```bash
 
     $ mkdir -p $HOME/.config/tizonia
-    $ cp /etc/tizonia/tizonia.conf/tizonia.conf $HOME/.config/tizonia/tizonia.conf
+    $ cp /etc/tizonia/tizonia.conf $HOME/.config/tizonia/tizonia.conf
 
     ( now edit $HOME/.config/tizonia/tizonia.conf )
 

--- a/player/src/tizprogramopts.cpp
+++ b/player/src/tizprogramopts.cpp
@@ -516,7 +516,7 @@ void tiz::programopts::print_usage_config () const
   print_license ();
   printf ("Configuration file location:\n\n");
   printf ("   tizonia.conf     $HOME/.config/tizonia/tizonia.conf\n");
-  printf ("                    See /etc/tizonia/tizonia.conf/tizonia.conf\n");
+  printf ("                    See /etc/tizonia/tizonia.conf\n");
   printf ("                    for an example.\n");
 }
 


### PR DESCRIPTION
In the README and the "config" help text, the path for the systemwide configuration contains a superfluous "/tizonia.conf".