### PR TITLE
vp8_decoder: do not reset port_def in reset_stream_parameters

### DIFF
--- a/plugins/vp8_decoder/src/vp8dprc.c
+++ b/plugins/vp8_decoder/src/vp8dprc.c
@@ -826,8 +826,6 @@ reset_stream_parameters (vp8d_prc_t * ap_prc)
   tiz_mem_set (&(ap_prc->info_), 0, sizeof (ap_prc->info_));
   ap_prc->info_.type = STREAM_UNKNOWN;
   free_codec_buffer (ap_prc);
-  TIZ_INIT_OMX_PORT_STRUCT (ap_prc->port_def_,
-                            ARATELIA_VP8_DECODER_OUTPUT_PORT_INDEX);
   ap_prc->p_inhdr_ = 0;
   ap_prc->p_outhdr_ = 0;
   ap_prc->first_buf_ = true;


### PR DESCRIPTION
This is causing issues on dynamic resolution changes.
Also I found that in all other plugins it is not done. So let's
do the same here.

The exact issue was that the color format get lost because disabling
the input port caused to call this TIZ_INIT_OMX_PORT_STRUCT. Then
tiz_krn_SetParameter_internal raised an error because of 0 color format
and 0 min buffer count.