### PR TITLE
vp8_decoder: add inport_SetParameter to set nBufferSize

### DIFF
--- a/plugins/vp8_decoder/src/Makefile.am
+++ b/plugins/vp8_decoder/src/Makefile.am
@@ -21,11 +21,14 @@ libtizvp8d_LTLIBRARIES = libtizvp8d.la
 
 noinst_HEADERS = \
 	vp8d.h \
+	vp8dinport.h \
+	vp8dinport_decls.h \
 	vp8dprc.h \
 	vp8dprc_decls.h
 
 libtizvp8d_la_SOURCES = \
 	vp8d.c \
+	vp8dinport.c \
 	vp8dprc.c
 
 libtizvp8d_la_CFLAGS = \

--- a/plugins/vp8_decoder/src/vp8d.c
+++ b/plugins/vp8_decoder/src/vp8d.c
@@ -42,6 +42,7 @@
 #include <tizvideoport.h>
 #include <tizvideoport_decls.h>
 
+#include "vp8dinport.h"
 #include "vp8dprc.h"
 #include "vp8d.h"
 
@@ -146,7 +147,7 @@ instantiate_input_port (OMX_HANDLETYPE ap_hdl)
   vp8type.nDCTPartitions = 0; /* 1 DCP partitiion */
   vp8type.bErrorResilientMode = OMX_FALSE;
 
-  return factory_new (tiz_get_type (ap_hdl, "tizvp8port"), &vp8_port_opts,
+  return factory_new (tiz_get_type (ap_hdl, "vp8dinport"), &vp8_port_opts,
                       &portdef, &encodings, &formats, &vp8type, &levels,
                       NULL /* OMX_VIDEO_PARAM_BITRATETYPE */);
 }
@@ -208,8 +209,10 @@ OMX_ComponentInit (OMX_HANDLETYPE ap_hdl)
 {
   tiz_role_factory_t role_factory;
   const tiz_role_factory_t * rf_list[] = {&role_factory};
+  tiz_type_factory_t vp8d_inport_type;
   tiz_type_factory_t vp8dprc_type;
-  const tiz_type_factory_t * tf_list[] = {&vp8dprc_type};
+  const tiz_type_factory_t * tf_list[] = {&vp8d_inport_type,
+                                          &vp8dprc_type};
   const tiz_eglimage_hook_t egl_validation_hook = {
     ARATELIA_VP8_DECODER_OUTPUT_PORT_INDEX,
     egl_image_validation_hook,
@@ -223,6 +226,11 @@ OMX_ComponentInit (OMX_HANDLETYPE ap_hdl)
   role_factory.nports = 2;
   role_factory.pf_proc = instantiate_processor;
 
+  strcpy ((OMX_STRING) vp8d_inport_type.class_name, "vp8dinport_class");
+  vp8d_inport_type.pf_class_init = vp8d_inport_class_init;
+  strcpy ((OMX_STRING) vp8d_inport_type.object_name, "vp8dinport");
+  vp8d_inport_type.pf_object_init = vp8d_inport_init;
+
   strcpy ((OMX_STRING) vp8dprc_type.class_name, "vp8dprc_class");
   vp8dprc_type.pf_class_init = vp8d_prc_class_init;
   strcpy ((OMX_STRING) vp8dprc_type.object_name, "vp8dprc");
@@ -232,7 +240,7 @@ OMX_ComponentInit (OMX_HANDLETYPE ap_hdl)
   tiz_check_omx (tiz_comp_init (ap_hdl, ARATELIA_VP8_DECODER_COMPONENT_NAME));
 
   /* Register the "vp8dprc" class */
-  tiz_check_omx (tiz_comp_register_types (ap_hdl, tf_list, 1));
+  tiz_check_omx (tiz_comp_register_types (ap_hdl, tf_list, 2));
 
   /* Register the component role */
   tiz_check_omx (tiz_comp_register_roles (ap_hdl, rf_list, 1));

--- a/plugins/vp8_decoder/src/vp8dinport.c
+++ b/plugins/vp8_decoder/src/vp8dinport.c
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2017 Julien Isorce
+ *
+ * This file is part of Tizonia
+ *
+ * Tizonia is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Tizonia is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Tizonia.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <limits.h>
+
+#include <tizplatform.h>
+#include <tizkernel.h>
+
+#include "vp8d.h"
+#include "vp8dinport.h"
+#include "vp8dinport_decls.h"
+#include "vp8dprc_decls.h"
+
+/*
+ * vp8dinport class
+ */
+
+static void * vp8d_inport_ctor (void * ap_obj, va_list * app)
+{
+   return super_ctor (typeOf (ap_obj, "vp8dinport"), ap_obj, app);
+}
+
+static void * vp8d_inport_dtor (void * ap_obj)
+{
+   return super_dtor (typeOf (ap_obj, "vp8dinport"), ap_obj);
+}
+
+/*
+ * from tiz_api
+ */
+
+static OMX_ERRORTYPE
+vp8d_inport_SetParameter (const void * ap_obj, OMX_HANDLETYPE ap_hdl,
+                          OMX_INDEXTYPE a_index, OMX_PTR ap_struct)
+{
+  OMX_ERRORTYPE err = OMX_ErrorNone;
+
+  assert (ap_obj);
+  assert (ap_hdl);
+  assert (ap_struct);
+
+  if (a_index == OMX_IndexParamPortDefinition) {
+    vp8d_prc_t * p_prc = tiz_get_prc (ap_hdl);
+    OMX_VIDEO_PORTDEFINITIONTYPE * p_def = &(p_prc->port_def_.format.video);
+    OMX_PARAM_PORTDEFINITIONTYPE * i_def = (OMX_PARAM_PORTDEFINITIONTYPE *) ap_struct;
+
+    /* Make changes only if there is a resolution change */
+    if ((p_def->nFrameWidth == i_def->format.video.nFrameWidth) &&
+        (p_def->nFrameHeight == i_def->format.video.nFrameHeight) &&
+        (p_def->xFramerate == i_def->format.video.xFramerate) &&
+        (p_def->eCompressionFormat == i_def->format.video.eCompressionFormat))
+      return err;
+
+    /* Set some default values if not set */
+    if (i_def->format.video.nStride == 0)
+      i_def->format.video.nStride = i_def->format.video.nFrameWidth;
+    if (i_def->format.video.nSliceHeight == 0)
+      i_def->format.video.nSliceHeight = i_def->format.video.nFrameHeight;
+
+    err = super_SetParameter (typeOf (ap_obj, "vp8dinport"), ap_obj,
+                              ap_hdl, a_index, ap_struct);
+    if (err == OMX_ErrorNone) {
+      tiz_port_t * p_obj = (tiz_port_t *) ap_obj;
+
+      /* Get a locally copy of port def. Useful for the early return above */
+      tiz_check_omx (tiz_api_GetParameter (tiz_get_krn (handleOf (p_prc)),
+                                           handleOf (p_prc),
+                                           OMX_IndexParamPortDefinition,
+                                           &(p_prc->port_def_)));
+
+      /* Set desired buffer size that will be used when allocating input buffers */
+      p_obj->portdef_.nBufferSize = p_def->nFrameWidth * p_def->nFrameHeight * 2;
+    }
+  }
+
+  return err;
+}
+
+/*
+ * vp8dinport_class
+ */
+
+static void *
+vp8d_inport_class_ctor (void * ap_obj, va_list * app)
+{
+   /* NOTE: Class methods might be added in the future. None for now. */
+   return super_ctor (typeOf (ap_obj, "vp8dinport_class"), ap_obj, app);
+}
+
+/*
+ * initialization
+ */
+
+void *
+vp8d_inport_class_init (void * ap_tos, void * ap_hdl)
+{
+  void * tizvp8port = tiz_get_type(ap_hdl, "tizvp8port");
+  void * vp8dinport_class
+    = factory_new(classOf(tizvp8port), "vp8dinport_class",
+                  classOf(tizvp8port), sizeof(vp8d_inport_class_t),
+                  ap_tos, ap_hdl, ctor, vp8d_inport_class_ctor, 0);
+  return vp8dinport_class;
+}
+
+void *
+vp8d_inport_init (void * ap_tos, void * ap_hdl)
+{
+  void * tizvp8port = tiz_get_type (ap_hdl, "tizvp8port");
+  void * vp8dinport_class = tiz_get_type (ap_hdl, "vp8dinport_class");
+  void * vp8dinport = factory_new
+    /* TIZ_CLASS_COMMENT: class type, class name, parent, size */
+    (vp8dinport_class, "vp8dinport", tizvp8port,
+    sizeof (vp8d_inport_t),
+    /* TIZ_CLASS_COMMENT: class constructor */
+    ap_tos, ap_hdl,
+    /* TIZ_CLASS_COMMENT: class constructor */
+    ctor, vp8d_inport_ctor,
+    /* TIZ_CLASS_COMMENT: class destructor */
+    dtor, vp8d_inport_dtor,
+    /* TIZ_CLASS_COMMENT: */
+    tiz_api_SetParameter, vp8d_inport_SetParameter,
+    /* TIZ_CLASS_COMMENT: stop value*/
+    0);
+
+   return vp8dinport;
+}

--- a/plugins/vp8_decoder/src/vp8dinport.h
+++ b/plugins/vp8_decoder/src/vp8dinport.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2017 Julien Isorce
+ *
+ * This file is part of Tizonia
+ *
+ * Tizonia is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Tizonia is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Tizonia.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef VP8DINPORT_H
+#define VP8DINPORT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *
+vp8d_inport_class_init (void * ap_tos, void * ap_hdl);
+void *
+vp8d_inport_init (void * ap_tos, void * ap_hdl);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VP8DINPORT_H */

--- a/plugins/vp8_decoder/src/vp8dinport_decls.h
+++ b/plugins/vp8_decoder/src/vp8dinport_decls.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2017 Julien Isorce
+ *
+ * This file is part of Tizonia
+ *
+ * Tizonia is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Tizonia is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Tizonia.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef VP8DINPORT_DECLS_H
+#define VP8DINPORT_DECLS_H
+
+#include <tizvp8port_decls.h>
+
+typedef struct vp8d_inport vp8d_inport_t;
+struct vp8d_inport
+{
+   /* Object */
+   const tiz_vp8port_t _;
+};
+
+typedef struct vp8d_inport_class vp8d_inport_class_t;
+struct vp8d_inport_class
+{
+   /* Class */
+   const tiz_vp8port_class_t _;
+   /* NOTE: Class methods might be added in the future */
+};
+
+#endif /* VP8DINPORT_DECLS_H */

--- a/plugins/vp8_decoder/src/vp8dprc.c
+++ b/plugins/vp8_decoder/src/vp8dprc.c
@@ -300,6 +300,10 @@ update_output_port_params (vp8d_prc_t * ap_prc)
                  "Updating video port format : nFrameHeight old [%d] new [%d]",
                  p_def->nFrameHeight, p_inf->height);
 
+      /* Effectively disable the output port, until the stream has been
+         identified and IL client is ready to re-enable */
+      ap_prc->out_port_disabled_ = true;
+
       p_def->nFrameHeight = p_inf->height;
       p_def->nFrameWidth = p_inf->width;
       p_def->xFramerate = framerate_q16;
@@ -784,9 +788,6 @@ decode_stream (vp8d_prc_t * ap_prc)
   if (ap_prc->first_buf_ && !ap_prc->eos_
       && (p_inhdr = get_input_buffer (ap_prc)))
     {
-      /* Effectively disable the output port, until the stream has been
-         identified and IL client is ready to re-enable */
-      ap_prc->out_port_disabled_ = true;
       tiz_check_omx (obtain_stream_info (ap_prc, p_inhdr));
       ap_prc->first_buf_ = false;
     }


### PR DESCRIPTION
This allows the component to decide the nBufferSize
depending on the resolution and framerate and prior
its internal parsing.
Indeed the demuxer will know this information before
the decoder.