### PR TITLE
Make aac_decoder optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,11 @@ AC_ARG_WITH(alsa,
         [build the ALSA-based OpenMAX IL plugin (default: yes)]),,
     with_alsa=yes)
 
+AC_ARG_WITH(aac,
+    AS_HELP_STRING([--with-aac],
+        [build the AAC-based OpenMAX IL plugin (default: yes)]),,
+    with_aac=yes)
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_SUBDIRS([3rdparty
                    include

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -16,7 +16,6 @@
 # along with Tizonia.  If not, see <http://www.gnu.org/licenses/>.
 
 REQUIRED_SUBDIRS = \
-	aac_decoder \
 	chromecast_renderer \
 	file_reader \
 	file_writer \
@@ -44,6 +43,9 @@ LIBSPOTIFY_SUBDIR= \
 ALSA_SUBDIR= \
 	pcm_renderer_alsa
 
+AAC_SUBDIR= \
+	aac_decoder
+
 SUBDIRS = ${REQUIRED_SUBDIRS}
 
 if WITH_LIBSPOTIFY
@@ -52,4 +54,8 @@ endif
 
 if WITH_ALSA
 SUBDIRS += ${ALSA_SUBDIR}
+endif
+
+if WITH_AAC
+SUBDIRS += ${AAC_SUBDIR}
 endif

--- a/plugins/configure.ac
+++ b/plugins/configure.ac
@@ -57,10 +57,16 @@ AC_ARG_WITH(alsa,
 
 AM_CONDITIONAL(WITH_ALSA, test "x$with_alsa" = xyes)
 
+AC_ARG_WITH(aac,
+    AS_HELP_STRING([--with-aac],
+        [build the AAC-based OpenMAX IL plugin (default: yes)]),,
+    with_aac=yes)
+
+AM_CONDITIONAL(WITH_AAC, test "x$with_aac" = xyes)
+
 AC_CONFIG_FILES([Makefile])
 
-AC_CONFIG_SUBDIRS([aac_decoder
-                   chromecast_renderer
+AC_CONFIG_SUBDIRS([chromecast_renderer
                    file_reader
                    file_writer
                    flac_decoder
@@ -90,6 +96,12 @@ fi
 if test "$with_alsa" = yes; then
    if test -d "$srcdir/pcm_renderer_alsa"; then
       AC_CONFIG_SUBDIRS([pcm_renderer_alsa])
+   fi
+fi
+
+if test "$with_aac" = yes; then
+   if test -d "$srcdir/aac_decoder"; then
+      AC_CONFIG_SUBDIRS([aac_decoder])
    fi
 fi
 


### PR DESCRIPTION
aac_decoder relies on libfaad which is legally problematic in some jurisdictions on account of extant patents.