### PR TITLE
Fixed the fetching of user likes on soundcloud

### DIFF
--- a/clients/soundcloud/soundcloudproxy/tizsoundcloudproxy.py
+++ b/clients/soundcloud/soundcloudproxy/tizsoundcloudproxy.py
@@ -199,7 +199,7 @@ class tizsoundcloudproxy(object):
             for resource in likes_resource:
                 like = resource.fields()
                 if like and like['streamable']:
-                    self.queue.append(track)
+                    self.queue.append(like)
                     count += 1
                 playlist = like.get('playlist')
                 if playlist:

--- a/clients/soundcloud/soundcloudproxy/tizsoundcloudproxy.py
+++ b/clients/soundcloud/soundcloudproxy/tizsoundcloudproxy.py
@@ -194,12 +194,11 @@ class tizsoundcloudproxy(object):
         """
         try:
             logging.info("enqueue_user_likes")
-            likes_resource = self.__api.get('/e1/me/likes', limit=100)
+            likes_resource = self.__api.get('/me/favorites', limit=100)
             count = 0
             for resource in likes_resource:
                 like = resource.fields()
-                track = like.get('track')
-                if track and track['streamable']:
+                if like and like['streamable']:
                     self.queue.append(track)
                     count += 1
                 playlist = like.get('playlist')


### PR DESCRIPTION
This pull fixes an error that always occurred when trying to listen to the user likes on soundcloud.
The endpoint seemed to be outdated and returned a HTTP 500 error so I updated it following the soundcloud documentation. A few adjustments had to be made to the response handling.