### PR TITLE
README: arch install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,17 @@ Debian-compatible system is by running the following command:
 - [tizonia-all-git (HEAD of master branch)](https://aur.archlinux.org/packages/tizonia-all-git/)
 
 ```bash
+    
+    # for the latest stable release
+    $ git clone https://aur.archlinux.org/tizonia-all.git
+    $ cd tizonia-all
+    $ makepkg -si
 
-    $ yaourt -S tizonia-all # for the latest stable release
-
-    # or
-
-    $ yaourt -S tizonia-all-git # for the bleeding edge
-
+    # or for the bleeding edge
+    $ git clone https://aur.archlinux.org/tizonia-all-git.git
+    $ cd tizonia-all
+    $ makepkg -si
+    
 ```
 
 ## Snap Package


### PR DESCRIPTION
## Rationale

Arch Linux does not support AUR helpers ([ref](https://wiki.archlinux.org/index.php/AUR_helpers)), so the README should reflect the recommended [install process](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).

I realize this is pedantic, but users should be guided towards the Arch way of installing AUR package, not towards an discontinued and unsupported AUR helper.

## Code change

No code has been changed, only the `README.md` file has been altered.