### PR TITLE
Add specific path to includes for vpx headers

### DIFF
--- a/plugins/vp8_decoder/src/Makefile.am
+++ b/plugins/vp8_decoder/src/Makefile.am
@@ -34,8 +34,7 @@ libtizvp8d_la_SOURCES = \
 libtizvp8d_la_CFLAGS = \
 	@TIZILHEADERS_CFLAGS@ \
 	@TIZPLATFORM_CFLAGS@ \
-	@TIZONIA_CFLAGS@ \
-	-I/usr/include/vpx
+	@TIZONIA_CFLAGS@
 
 libtizvp8d_la_LDFLAGS = -version-info @SHARED_VERSION_INFO@ @SHLIB_VERSION_ARG@
 

--- a/plugins/vp8_decoder/src/vp8dprc_decls.h
+++ b/plugins/vp8_decoder/src/vp8dprc_decls.h
@@ -36,8 +36,8 @@ extern "C" {
 #include <stdbool.h>
 
 #define VPX_CODEC_DISABLE_COMPAT 1
-#include <vpx_decoder.h>
-#include <vp8dx.h>
+#include <vpx/vpx_decoder.h>
+#include <vpx/vp8dx.h>
 
 #include <tizprc_decls.h>
 


### PR DESCRIPTION
This should be painless to autotools. I wanted to add pkgconfig detection as well, but I have no idea how old are the systems that have to be supported.
