### PR TITLE
Use external libev if available

### DIFF
--- a/libtizplatform/src/meson.build
+++ b/libtizplatform/src/meson.build
@@ -13,7 +13,6 @@ configure_file(input: 'tizplatform_config.h.in',
 libtizplatform_sources = [
    'http-parser/http_parser.c',
    'avl/avl.c',
-   'ev/ev.c',
    'tizplatform.c',
    'tizlog.c',
    'tizomxutils.c',
@@ -39,10 +38,6 @@ libtizplatform_sources = [
 install_headers(
    'utarray/utarray.h',
    'avl/avl.h',
-   'ev/ev.h',
-   'ev/ev_vars.h',
-   'ev/ev_wrap.h',
-   'ev/ev_epoll.c',
    'http-parser/http_parser.h',
    'tizplatform.h',
    'tizmacros.h',
@@ -69,18 +64,37 @@ install_headers(
    install_dir: tizincludedir
 )
 
+libtizplatform_deps = [
+   tizilheaders_dep,
+   libcurl_dep,
+   pthread_dep,
+   uuid_dep,
+   log4c_dep
+]
+
+if have_system_libev
+   libtizplatform_sources += [
+      'ev/ev.c'
+   ]
+   install_headers(
+      'ev/ev.h',
+      'ev/ev_vars.h',
+      'ev/ev_wrap.h',
+      'ev/ev_epoll.c',
+      install_dir: tizincludedir
+   )
+   libtizplatform_deps += [
+      libev_dep
+   ]
+endif
+
+
 
 libtizplatform = library(
    'tizplatform',
    version: tizversion,
    sources: libtizplatform_sources,
-   dependencies: [
-      tizilheaders_dep,
-      libcurl_dep,
-      pthread_dep,
-      uuid_dep,
-      log4c_dep
-   ],
+   dependencies: libtizplatform_deps,
    install: true
 )
 
@@ -89,4 +103,3 @@ libtizplatform_dep = declare_dependency(
     link_with: libtizplatform,
     dependencies: pthread_dep
 )
-

--- a/meson.build
+++ b/meson.build
@@ -84,6 +84,8 @@ else
    python3 = pymod.find_installation('python3', required: true)
 endif
 
+libev_dep = dependency('libev', required: false)
+have_system_libev = libev_dep.found()
 
 # there is also a config.h created in 3rdparty/dbus-cplusplus
 # see if unifying them would be preferable
@@ -112,6 +114,11 @@ endif
 
 if enable_blocking_sendcommand
    config_h.set10('SENDCOMMAND_SHOULD_BLOCK', true, description: 'Blocking behaviour of SendCommand API is enabled')
+endif
+
+# not present in the original
+if have_system_libev
+   config_h.set10('HAVE_SYSTEM_LIBEV', true, description: 'Define this to 1 if you have libev on your system')
 endif
 
 config_h.set_quoted('PACKAGE_VERSION', meson.project_version(), description: 'Define to the version of this package.')


### PR DESCRIPTION
libev is not actually linked to, apparently the only thing that's used is ev.h for some struct definitions.
