### PR TITLE
fix: Fix compile error (change boost placeholders syntax)

### DIFF
--- a/cast/tizcastd/src/tizcastd.cpp
+++ b/cast/tizcastd/src/tizcastd.cpp
@@ -67,9 +67,9 @@ tizcastd::tizcastd (Tiz::DBus::Connection &a_connection)
 {
   TIZ_LOG (TIZ_PRIORITY_TRACE, "Constructing tizcastd...");
   p_worker_ = new tiz::cast::worker (
-      boost::bind (&tizcastd::cast_status_forwarder, this, _1, _2, _3),
-      boost::bind (&tizcastd::media_status_forwarder, this, _1, _2, _3),
-      boost::bind (&tizcastd::error_status_forwarder, this, _1, _2, _3));
+      boost::bind (&tizcastd::cast_status_forwarder, this, boost:placeholders::_1, boost:placeholders::_2, boost:placeholders::_3),
+      boost::bind (&tizcastd::media_status_forwarder, this, boost:placeholders::_1, boost:placeholders::_2, boost:placeholders::_3),
+      boost::bind (&tizcastd::error_status_forwarder, this, boost:placeholders::_1, boost:placeholders::_2, boost:placeholders::_3));
   assert (p_worker_);
   p_worker_->init ();
 }

--- a/clients/chromecast/libtizchromecast/src/tizchromecast.cpp
+++ b/clients/chromecast/libtizchromecast/src/tizchromecast.cpp
@@ -105,9 +105,9 @@ tiz_chromecast_error_t tizchromecast::start ()
       typedef boost::function< void (std::string, float) > handler_fn1;
       typedef boost::function< void (std::string, int) > handler_fn2;
       handler_fn1 cast_status_handler (
-          boost::bind (&tizchromecast::new_cast_status, this, _1, _2));
+          boost::bind (&tizchromecast::new_cast_status, this, boost:placeholders::_1, boost:placeholders::_2));
       handler_fn2 media_status_handler (
-          boost::bind (&tizchromecast::new_media_status, this, _1, _2));
+          boost::bind (&tizchromecast::new_media_status, this, boost:placeholders::_1, boost:placeholders::_2));
       try_catch_wrapper (py_cc_proxy.attr ("activate") (
           bp::make_function (cast_status_handler),
           bp::make_function (media_status_handler)));

--- a/player/src/tizprogramopts.cpp
+++ b/player/src/tizprogramopts.cpp
@@ -3430,7 +3430,7 @@ bool tiz::programopts::validate_sampling_rates_argument (std::string &msg)
 
 void tiz::programopts::register_consume_function (const consume_mem_fn_t cf)
 {
-  consume_functions_.push_back (boost::bind (boost::mem_fn (cf), this, _1, _2));
+  consume_functions_.push_back (boost::bind (boost::mem_fn (cf), this, boost:placeholders::_1, boost:placeholders::_2));
 }
 
 int tiz::programopts::call_handler (


### PR DESCRIPTION
Fix tizonia `error: ‘_1’ was not declared in this scope ` buiild error after boost lib update

```
 note: #pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.
 ```