### PR TITLE
feat: include raspbian bullseye into the install script 

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -49,6 +49,8 @@ if echo "$RELIDS" | grep raspbian; then
         RELEASE="stretch"; PYVER=2 ; MOPRELEASE="stretch"
     elif echo "$RELIDS" | grep jessie; then
         RELEASE="jessie" ; PYVER=2 ; MOPRELEASE="jessie"
+    elif echo "$RELIDS" | grep bullseye; then
+        RELEASE="jessie" ; PYVER=2 ; MOPRELEASE="bullseye"
     else
         echo "Can't find a supported Raspbian distribution."
         exit 1


### PR DESCRIPTION
I tried to install Tizonia via `install.sh` but the bullseye release wasn't there.
This PR addresses this issue.