### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,6 @@ following distro/arch combinations:
 
 ## Arch User Repository (AUR)
 
-- [tizonia-all (for the latest released version)](https://aur.archlinux.org/packages/tizonia-all/)
 - [tizonia-all-git (HEAD of master branch)](https://aur.archlinux.org/packages/tizonia-all-git/)
 
 <details><summary><b>Show details</b></summary>


### PR DESCRIPTION
the link https://aur.archlinux.org/packages/tizonia-all/ no longer exists so it is best to remove it