### PR TITLE
Add v1 roadmap workflow templates and README banner

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-roadmap-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-roadmap-task.yml
@@ -1,0 +1,64 @@
+name: Agent roadmap task
+description: Roadmap task intended for autonomous coding agents.
+title: "[v1] "
+labels: ["roadmap:v1", "agent-ready"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: State the concrete outcome expected from this issue.
+      placeholder: What should be true when this issue is complete?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Include project background, affected subsystems, and useful links.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List the changes that are in scope for this task.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: List work the agent must not do in this issue.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: List blocking issues or prerequisite decisions.
+      placeholder: Blocked by #...
+    validations:
+      required: true
+  - type: textarea
+    id: implementation_notes
+    attributes:
+      label: Implementation notes
+      description: Provide enough detail for an agent to work self-directed.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Define observable conditions that make this issue complete.
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Commands, smoke tests, or manual checks required before closing.
+      render: shell
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Linked Issue
+
+Closes #
+
+## Summary
+
+- 
+
+## Verification
+
+Commands run:
+
+```bash
+
+```
+
+## Scope Checklist
+
+- [ ] This PR is limited to the linked issue.
+- [ ] I did not broaden v1 support beyond Ubuntu 24.04 `amd64`.
+- [ ] I did not reintroduce removed/deferred services into the v1 default path.
+- [ ] I updated docs, packaging, or tests when the change affects them.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 # The Tizonia Project
 
+> **Revival in progress:** Tizonia is being revived for a new v1 release
+> targeting Ubuntu 24.04 `amd64`. During this work, legacy installation
+> instructions and some streaming-service documentation may be stale. Follow the
+> [v1 roadmap issues](https://github.com/tizonia/tizonia-openmax-il/issues?q=is%3Aissue+label%3Aroadmap%3Av1)
+> for current status.
+
 * A command-line streaming music client/server for Linux.
 * Support for Spotify (Premium), Google Play Music (free and paid tiers),
   YouTube, SoundCloud, TuneIn and iHeart Internet Radio directories, Plex
@@ -436,4 +442,3 @@ guidelines](CONTRIBUTING.md) and don't hesitate to ask (via the bug tracker,
 Here are some of our contributors:
 
 [![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/0)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/0)[![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/1)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/1)[![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/2)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/2)[![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/3)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/3)[![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/4)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/4)[![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/5)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/5)[![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/6)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/6)[![](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/images/7)](https://sourcerer.io/fame/tizonia/tizonia/tizonia-openmax-il/links/7)
-


### PR DESCRIPTION
## Summary

- Add the agent-ready roadmap issue template and PR template for v1 work.
- Add a README banner that signals the Ubuntu 24.04 amd64 revival is in progress.

Closes #814
Closes #815

## Verification

Commands run:

```bash
git diff --check
python3 - <<'PY'
import yaml
yaml.safe_load(open(".github/ISSUE_TEMPLATE/agent-roadmap-task.yml"))
print("issue template yaml ok")
PY
sed -n '1,80p' README.md
```

## Scope Checklist

- [x] This PR is limited to the linked issues.
- [x] I did not broaden v1 support beyond Ubuntu 24.04 `amd64`.
- [x] I did not reintroduce removed/deferred services into the v1 default path.
- [x] I updated docs/workflow templates for the change.
