### PR TITLE
Add minimal Ubuntu 24 core Meson CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI - core build (Ubuntu 24.04)
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  core-build:
+    name: Core Meson build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install core build dependencies
+        run: |
+          sudo apt-get update
+          # Derived from the core Meson dependency declarations with player,
+          # clients, docs, tests, libspotify, and all plugins disabled.
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            meson \
+            ninja-build \
+            pkg-config \
+            libdbus-1-dev \
+            libexpat1-dev \
+            liblog4c-dev \
+            uuid-dev \
+            libsqlite3-dev \
+            python3-dev \
+            libcurl4-openssl-dev
+
+      - name: Configure core-only build
+        run: |
+          meson setup build \
+            --buildtype=plain \
+            --wrap-mode=nodownload \
+            -Dlibspotify=false \
+            -Dplayer=false \
+            -Dclients=false \
+            -Ddocs=false \
+            -Dtest=false \
+            -Dplugins=[]
+
+      - name: Compile core
+        run: meson compile -C build


### PR DESCRIPTION
## Summary

- Add the first GitHub Actions workflow for a minimal Ubuntu 24.04 amd64 core Meson build.
- Configure Meson with player, clients, docs, tests, libspotify, and plugins disabled so the check stays dependency-light and service-free.
- Install only the apt packages needed by the core Meson dependency graph.

Closes #831

## Verification

Commands run locally:

```bash
python3 - <<'PY'
import yaml
with open(".github/workflows/ci.yml") as f:
    yaml.safe_load(f)
print("workflow yaml ok")
PY
git diff --check
```

GitHub Actions proof on Ubuntu 24.04 amd64:

- Good path: `Core Meson build` passed in 28s on run https://github.com/tizonia/tizonia-openmax-il/actions/runs/28739067126/job/85218466215
- Red path: temporary syntax error in `libtizplatform/src/tizplatform.c` failed in 24s on run https://github.com/tizonia/tizonia-openmax-il/actions/runs/28739095798/job/85218540833
- Final clean path: after removing the temporary break and force-pushing a clean branch, `Core Meson build` passed in 33s on run https://github.com/tizonia/tizonia-openmax-il/actions/runs/28739144704/job/85218670113

Notes:

- Local apt-based reproduction could not be completed in this workspace because sudo requires an interactive password. The GitHub Actions check-run is the Ubuntu 24.04 amd64 execution proof for this workflow.
- `-Dtest=false` is intentional for this first pass: current core test wiring includes `libtizonia/tests` depending on `libtizgmusic_dep`, which is unavailable when clients are disabled.

## Scope Checklist

- [x] This PR is limited to the linked issue.
- [x] I did not broaden v1 support beyond Ubuntu 24.04 `amd64`.
- [x] I did not reintroduce removed/deferred services into the v1 default path.
- [x] I updated docs, packaging, or tests when the change affects them.
