### PR TITLE
[v1/e2e] Document Agent Mail member ID usage

### DIFF
--- a/CONTRIBUTING-agents.md
+++ b/CONTRIBUTING-agents.md
@@ -14,6 +14,8 @@ pull request template.
   `amd64`.
 - Use `area:*` labels to understand the primary ownership area, for example
   `area:docs`, `area:build`, `area:ci`, or `area:plugins`.
+- When requesting leader acknowledgment through Agent Mail, use the leader's
+  Agent Mail member ID, not the team slot ID.
 - Read linked issues and pull requests before editing files.
 
 ## Scope Discipline


### PR DESCRIPTION
## Linked Issue

Closes #837

## Summary

- Clarify that Agent Mail leader acknowledgments must use member IDs rather than team slot IDs.

## Verification

Commands run:

```bash
grep -q "member ID" CONTRIBUTING-agents.md && echo "member ID guidance present"
# member ID guidance present

git diff --check
# no output
```

## Scope Checklist

- [x] This PR is limited to the linked issue.
- [x] I did not broaden v1 support beyond Ubuntu 24.04 `amd64`.
- [x] I did not reintroduce removed/deferred services into the v1 default path.
- [x] I updated docs, packaging, or tests when the change affects them.
