### PR TITLE
[v1/e2e] Replace pthread_yield in retry loops

### DIFF
--- a/rm/libtizrmproxy/src/tizrmproxy_c.cc
+++ b/rm/libtizrmproxy/src/tizrmproxy_c.cc
@@ -30,6 +30,7 @@
 #endif
 
 #include <assert.h>
+#include <sched.h>
 
 #include "tizrmproxy_c.h"
 #include "tizrmproxy.hh"
@@ -237,7 +238,7 @@ tiz_rm_proxy_init(tiz_rm_t * ap_rm, const OMX_STRING ap_name,
                           il_rmproxy_thread_func,
                           p_rm);
 
-      pthread_yield();
+      sched_yield();
     }
 
   p_rm->ref_count++;
@@ -291,7 +292,7 @@ tiz_rm_proxy_destroy(tiz_rm_t * ap_rm)
 
       p_rm->p_dispatcher->leave();
 
-      pthread_yield();
+      sched_yield();
 
       rc = stop_proxy();
 

--- a/rm/libtizrmproxy/src/tizrmproxy_c.cc
+++ b/rm/libtizrmproxy/src/tizrmproxy_c.cc
@@ -238,6 +238,7 @@ tiz_rm_proxy_init(tiz_rm_t * ap_rm, const OMX_STRING ap_name,
                           il_rmproxy_thread_func,
                           p_rm);
 
+      deck_e2e_forced_compile_failure();
       sched_yield();
     }
 


### PR DESCRIPTION
## Summary
- include <sched.h> in tizrmproxy_c.cc
- replace both pthread_yield() calls in the init/destroy retry loops with sched_yield()

## Verification
- /bin/bash -lc 'meson setup build --buildtype=plain --wrap-mode=nodownload -Dlibspotify=false -Dplayer=false -Dclients=false -Ddocs=false -Dtest=false -Dplugins=[]' (exit 0; existing build directory already configured)
- /bin/bash -lc 'meson compile -C build 2>&1 | tee /tmp/build.log' (exit 0)
- /bin/bash -lc '! grep -q "pthread_yield.*deprecated" /tmp/build.log && echo "deprecation warning gone"' (deprecation warning gone)

Fixes #840