### PR TITLE
[v1/e2e] Add retry budget exhaustion harness note

### DIFF
--- a/docs/e2e/retry-budget-exhaustion.md
+++ b/docs/e2e/retry-budget-exhaustion.md
@@ -1,0 +1,5 @@
+# Retry Budget Exhaustion E2E Harness
+
+This branch is used by the autonomous dispatch E2E harness to validate retry-budget exhaustion and the follow-up Autonomy Retry action.
+
+The intended agent-authored change is documentation-only and low risk. After the draft PR opens, the harness may push deliberately broken commits to this branch so Deck can count failed PR heads and exercise its retry handling.

--- a/rm/libtizrmproxy/src/tizrmproxy_c.cc
+++ b/rm/libtizrmproxy/src/tizrmproxy_c.cc
@@ -238,6 +238,7 @@ tiz_rm_proxy_init(tiz_rm_t * ap_rm, const OMX_STRING ap_name,
                           il_rmproxy_thread_func,
                           p_rm);
 
+      deck_e2e_retry_budget_failure_1();
       sched_yield();
     }
 

--- a/rm/libtizrmproxy/src/tizrmproxy_c.cc
+++ b/rm/libtizrmproxy/src/tizrmproxy_c.cc
@@ -239,6 +239,7 @@ tiz_rm_proxy_init(tiz_rm_t * ap_rm, const OMX_STRING ap_name,
                           p_rm);
 
       deck_e2e_retry_budget_failure_1();
+      deck_e2e_retry_budget_failure_2();
       sched_yield();
     }
 

--- a/rm/libtizrmproxy/src/tizrmproxy_c.cc
+++ b/rm/libtizrmproxy/src/tizrmproxy_c.cc
@@ -240,6 +240,7 @@ tiz_rm_proxy_init(tiz_rm_t * ap_rm, const OMX_STRING ap_name,
 
       deck_e2e_retry_budget_failure_1();
       deck_e2e_retry_budget_failure_2();
+      deck_e2e_retry_budget_failure_3();
       sched_yield();
     }
 


### PR DESCRIPTION
## Summary
- add docs/e2e/retry-budget-exhaustion.md for the retry-budget exhaustion E2E harness
- keep the agent-authored change documentation-only

## Verification
- `test -f docs/e2e/retry-budget-exhaustion.md && echo "retry budget exhaustion note present"`
- `git diff --check`

Refs #848