### PR TITLE
docs: add CI signal grace-window note

### DIFF
--- a/docs/e2e/ci-signal-grace-window.md
+++ b/docs/e2e/ci-signal-grace-window.md
@@ -1,0 +1,9 @@
+# CI Signal Grace-Window Validation
+
+This note records the T-S8 end-to-end validation for Claude Deck autonomous
+dispatch on issue #854.
+
+The scenario exercises the default CI signal grace window with a 60 second
+dispatch interval and a 120 second check-signal grace period. The expected
+path is a tiny docs-only draft PR that lets Deck observe CI status without
+changing workflows, build configuration, repository settings, or code.


### PR DESCRIPTION
Closes #854.

Summary:
- Add docs/e2e/ci-signal-grace-window.md describing the T-S8 CI signal grace-window validation.
- Document the 60s dispatch interval and 120s check-signal grace period.

Verification:
- `test -f docs/e2e/ci-signal-grace-window.md && echo "CI signal grace-window note present"`
- `git diff --check`
- `git status --short`