### PR TITLE
ci: add Ubuntu 24.04 build container

### DIFF
--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY apt-packages.txt /tmp/tizonia-apt-packages.txt
+
+RUN apt-get update \
+    && grep -Ev '^[[:space:]]*(#|$)' /tmp/tizonia-apt-packages.txt \
+        | xargs apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work/tizonia-openmax-il
+
+CMD ["/bin/bash"]

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -1,15 +1,29 @@
+# syntax=docker/dockerfile:1
+
 FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG TIZONIA_INSTALL_DOCS=false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 COPY apt-packages.txt /tmp/tizonia-apt-packages.txt
 
 RUN apt-get update \
-    && grep -Ev '^[[:space:]]*(#|$)' /tmp/tizonia-apt-packages.txt \
-        | xargs apt-get install -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+    && sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' /tmp/tizonia-apt-packages.txt \
+       | xargs apt-get install -y --no-install-recommends \
+    && if [ "${TIZONIA_INSTALL_DOCS}" = "true" ]; then \
+         apt-get install -y --no-install-recommends \
+           doxygen \
+           graphviz \
+           plantuml \
+           python3-alabaster \
+           python3-breathe \
+           python3-recommonmark \
+           python3-sphinxcontrib.plantuml \
+           python3-sphinx; \
+       fi \
+    && rm -rf /var/lib/apt/lists/* /tmp/tizonia-apt-packages.txt
 
 WORKDIR /work/tizonia-openmax-il
 

--- a/ci/ubuntu-24.04/README.md
+++ b/ci/ubuntu-24.04/README.md
@@ -1,35 +1,48 @@
-# Ubuntu 24.04 v1 Build Container
+# Ubuntu 24.04 amd64 build container
 
-This directory defines the Ubuntu 24.04 `amd64` baseline environment for v1
-source builds. The image uses only Ubuntu archive packages from
-`apt-packages.txt`; it does not configure external APT repositories or install
-Python packages outside apt.
+This directory defines the v1 baseline build environment for Ubuntu 24.04
+`amd64`. It uses only Ubuntu archive packages listed in `apt-packages.txt` and
+does not add external APT repositories or install Python packages outside the
+Ubuntu archive.
 
-Build the image from the repository root:
+## Build the image
 
-```sh
-docker build -f ci/ubuntu-24.04/Dockerfile -t tizonia-v1-ubuntu-24.04 .
+From the repository root:
+
+```bash
+docker build \
+  --platform linux/amd64 \
+  -t tizonia-build:ubuntu-24.04 \
+  -f ci/ubuntu-24.04/Dockerfile \
+  ci/ubuntu-24.04
 ```
 
-Enter the environment with the current checkout mounted at the expected working
-directory:
+Documentation tooling is excluded by default. To include the Ubuntu-packaged
+Sphinx and Doxygen dependencies for a docs-enabled build, add:
 
-```sh
+```bash
+--build-arg TIZONIA_INSTALL_DOCS=true
+```
+
+## Enter the environment
+
+From the repository root:
+
+```bash
 docker run --rm -it \
-  -v "$PWD:/work/tizonia-openmax-il" \
+  --platform linux/amd64 \
+  --user "$(id -u):$(id -g)" \
+  -e HOME=/tmp \
+  -v "$PWD":/work/tizonia-openmax-il \
   -w /work/tizonia-openmax-il \
-  tizonia-v1-ubuntu-24.04
+  tizonia-build:ubuntu-24.04
 ```
 
-Run the baseline build inside the container:
+## Run the baseline build
 
-```sh
-rm -rf build
+Inside the container:
+
+```bash
 meson setup build -Dlibspotify=false -Ddocs=false
 ninja -C build -j1
 ```
-
-Documentation tooling is intentionally not installed in the baseline image. If
-you are validating a docs-enabled build, install the optional documentation
-packages listed at the end of `apt-packages.txt` before configuring with
-`-Ddocs=true`.

--- a/ci/ubuntu-24.04/README.md
+++ b/ci/ubuntu-24.04/README.md
@@ -1,0 +1,35 @@
+# Ubuntu 24.04 v1 Build Container
+
+This directory defines the Ubuntu 24.04 `amd64` baseline environment for v1
+source builds. The image uses only Ubuntu archive packages from
+`apt-packages.txt`; it does not configure external APT repositories or install
+Python packages outside apt.
+
+Build the image from the repository root:
+
+```sh
+docker build -f ci/ubuntu-24.04/Dockerfile -t tizonia-v1-ubuntu-24.04 .
+```
+
+Enter the environment with the current checkout mounted at the expected working
+directory:
+
+```sh
+docker run --rm -it \
+  -v "$PWD:/work/tizonia-openmax-il" \
+  -w /work/tizonia-openmax-il \
+  tizonia-v1-ubuntu-24.04
+```
+
+Run the baseline build inside the container:
+
+```sh
+rm -rf build
+meson setup build -Dlibspotify=false -Ddocs=false
+ninja -C build -j1
+```
+
+Documentation tooling is intentionally not installed in the baseline image. If
+you are validating a docs-enabled build, install the optional documentation
+packages listed at the end of `apt-packages.txt` before configuring with
+`-Ddocs=true`.

--- a/ci/ubuntu-24.04/apt-packages.txt
+++ b/ci/ubuntu-24.04/apt-packages.txt
@@ -1,0 +1,52 @@
+# Ubuntu 24.04 amd64 packages for the v1 baseline source build:
+#   meson setup build -Dlibspotify=false -Ddocs=false
+build-essential
+ca-certificates
+check
+git
+libasound2-dev
+libboost-chrono-dev
+libboost-filesystem-dev
+libboost-program-options-dev
+libboost-python-dev
+libboost-system-dev
+libboost-thread-dev
+libcurl4-openssl-dev
+libdbus-1-dev
+libev-dev
+libexpat1-dev
+libfaad-dev
+libfishsound1-dev
+libflac-dev
+liblog4c-dev
+libmad0-dev
+libmediainfo-dev
+libmp3lame-dev
+libmpg123-dev
+liboggz2-dev
+libopus-dev
+libopusfile-dev
+libpulse-dev
+libsdl1.2-dev
+libsndfile1-dev
+libsqlite3-dev
+libtag1-dev
+libvpx-dev
+meson
+ninja-build
+pkg-config
+python3
+python3-dev
+python3-venv
+uuid-dev
+
+# Optional documentation packages for builds configured with -Ddocs=true.
+# Keep these out of the baseline image unless docs are being validated.
+# default-jre
+# doxygen
+# graphviz
+# python3-alabaster
+# python3-breathe
+# python3-recommonmark
+# python3-sphinx
+# python3-sphinxcontrib.plantuml

--- a/ci/ubuntu-24.04/apt-packages.txt
+++ b/ci/ubuntu-24.04/apt-packages.txt
@@ -1,24 +1,42 @@
-# Ubuntu 24.04 amd64 packages for the v1 baseline source build:
-#   meson setup build -Dlibspotify=false -Ddocs=false
+# Ubuntu 24.04 amd64 baseline packages for the issue #816 non-doc Meson build.
+
+# Toolchain and Meson frontend. build-essential provides GCC, G++, and make.
 build-essential
-ca-certificates
-check
-git
-libasound2-dev
+meson
+ninja-build
+pkg-config
+
+# Python 3 headers and embedding support used by Meson and Boost.Python targets.
+python3
+python3-dev
+python3-all-dev
+
+# Boost modules requested by the Meson build.
 libboost-chrono-dev
 libboost-filesystem-dev
 libboost-program-options-dev
 libboost-python-dev
 libboost-system-dev
 libboost-thread-dev
+
+# Core libraries.
+libatomic-ops-dev
 libcurl4-openssl-dev
 libdbus-1-dev
 libev-dev
 libexpat1-dev
+liblog4c-dev
+libsqlite3-dev
+uuid-dev
+
+# Test dependency declared by Meson when tests are enabled.
+check
+
+# Player, codec, and rendering dependencies for the default non-doc build.
+libasound2-dev
 libfaad-dev
 libfishsound1-dev
 libflac-dev
-liblog4c-dev
 libmad0-dev
 libmediainfo-dev
 libmp3lame-dev
@@ -29,24 +47,5 @@ libopusfile-dev
 libpulse-dev
 libsdl1.2-dev
 libsndfile1-dev
-libsqlite3-dev
 libtag1-dev
 libvpx-dev
-meson
-ninja-build
-pkg-config
-python3
-python3-dev
-python3-venv
-uuid-dev
-
-# Optional documentation packages for builds configured with -Ddocs=true.
-# Keep these out of the baseline image unless docs are being validated.
-# default-jre
-# doxygen
-# graphviz
-# python3-alabaster
-# python3-breathe
-# python3-recommonmark
-# python3-sphinx
-# python3-sphinxcontrib.plantuml


### PR DESCRIPTION
## Summary
- add a reusable Ubuntu 24.04 amd64 container definition for v1 baseline source builds
- keep the baseline build dependency list visible in `ci/ubuntu-24.04/apt-packages.txt` for later CI reuse
- document image build, container entry, and baseline Meson/Ninja commands
- keep docs tooling out of the default image, with an explicit docs build arg for Ubuntu-packaged Sphinx/Doxygen dependencies

Closes #816

## Verification
- `git diff --check`
- baseline package manifest resolves to Ubuntu 24.04 candidates with `apt-cache policy`
- optional docs packages resolve to Ubuntu 24.04 candidates with `apt-cache policy`
- forbidden legacy setup terms are absent from `ci/ubuntu-24.04`
- `gh pr checks 862 --watch --interval 10` (Core Meson build passed)
- Docker unavailable locally (`docker: command not found`), so container build/run and in-container Meson/Ninja verification could not be executed
- host is missing many baseline packages, so the issue Meson/Ninja commands were not run outside the container