### PR TITLE
[e2e] Document agent test-result reporting

### DIFF
--- a/CONTRIBUTING-agents.md
+++ b/CONTRIBUTING-agents.md
@@ -45,8 +45,8 @@ pull request template.
 - Run every command in the issue's Verification block before marking the work
   ready.
 - For docs-only issues, also run any lightweight checks requested by the issue.
-- If a command cannot run locally, state why in the pull request and leave the
-  issue open for follow-up.
+- In the pull request, report each exact command and its pass/fail result, and
+  list any skipped or unavailable checks with the reason.
 - Do not close an issue because the change looks obvious; close it only after
   the requested verification passes or the maintainer accepts the documented
   exception.


### PR DESCRIPTION
Closes #867

## Summary
- Require exact commands, pass/fail results, and skipped or unavailable checks in agent PR verification reports.

## Verification
- `git diff --check` — pass
- `meson compile -C build -j4` — not run; docs-only issue and no build changes in scope.