### PR TITLE
docs: require changed-file scope check

### DIFF
--- a/CONTRIBUTING-agents.md
+++ b/CONTRIBUTING-agents.md
@@ -46,6 +46,7 @@ pull request template.
   ready.
 - For docs-only issues, also run any lightweight checks requested by the issue.
 - Run `git diff --check` before requesting review.
+- Before requesting review, confirm `git diff --name-only` lists only intended files.
 - In the pull request, report each exact command and its pass/fail result, and
   list any skipped or unavailable checks with the reason.
 - Do not close an issue because the change looks obvious; close it only after


### PR DESCRIPTION
Closes #871

## Summary
- Require confirming `git diff --name-only` lists only intended files before review.

## Verification
- `git diff --check` (pass)
- `git diff --name-only` lists only `CONTRIBUTING-agents.md` (pass)
- No skipped or unavailable checks.